### PR TITLE
Missing /libc/string/ functions

### DIFF
--- a/include/machine/limits.h
+++ b/include/machine/limits.h
@@ -38,6 +38,10 @@
 #define	SSIZE_MAX	LONG_MAX	/* max value for a ssize_t */
 
 #if !defined(_POSIX_SOURCE)
+
+#define LONG_BIT		32
+#define WORD_BIT		16
+
 #define	SIZE_T_MAX	ULONG_MAX	/* max value for a size_t */
 
 #endif /* !_POSIX_SOURCE */

--- a/include/signal.h
+++ b/include/signal.h
@@ -51,6 +51,7 @@
 #if !defined(_ANSI_SOURCE) && !defined(_POSIX_SOURCE)
 extern __const char *__const sys_signame[NSIG];
 extern __const char *__const sys_siglist[NSIG];
+extern __const int sys_nsig;
 #endif
 
 __BEGIN_DECLS

--- a/include/string.h
+++ b/include/string.h
@@ -54,45 +54,67 @@ typedef	_BSD_SIZE_T_	size_t;
 #include <sys/cdefs.h>
 #endif
 
+/*
+ * Prototype functions which were historically defined in <string.h>, but
+ * are required by POSIX to be prototyped in <strings.h>.
+ */
+#include <strings.h>
+
 __BEGIN_DECLS
+/* __POSIX_VISIBLE || __XSI_VISIBLE */
+void	*memccpy __P((void *, const void *, int, size_t));
 void	*memchr __P((const void *, int, size_t));
 int	 memcmp __P((const void *, const void *, size_t));
 void	*memcpy __P((void *, const void *, size_t));
 void	*memmove __P((void *, const void *, size_t));
 void	*memset __P((void *, int, size_t));
+
+char	*stpcpy __P((char *, const char *));
+char	*stpncpy __P((char *, const char *, size_t));
+
 char	*strcat __P((char *, const char *));
 char	*strchr __P((const char *, int));
 int	 strcmp __P((const char *, const char *));
 int	 strcoll __P((const char *, const char *));
 char	*strcpy __P((char *, const char *));
 size_t	 strcspn __P((const char *, const char *));
+char	*strdup __P((const char *));
+
 char	*strerror __P((int));
+int	 strerror_r __P((int, char *, size_t));
+
 size_t	 strlen __P((const char *));
 char	*strncat __P((char *, const char *, size_t));
 int	 strncmp __P((const char *, const char *, size_t));
 char	*strncpy __P((char *, const char *, size_t));
+char	*strndup __P((const char *, size_t));
+size_t	 strnlen __P((const char *, size_t));
 char	*strpbrk __P((const char *, const char *));
 char	*strrchr __P((const char *, int));
+char	*strsignal __P((int));
 size_t	 strspn __P((const char *, const char *));
 char	*strstr __P((const char *, const char *));
 char	*strtok __P((char *, const char *));
+char	*strtok_r __P((char *, const char *, char **));
 size_t	 strxfrm __P((char *, const char *, size_t));
 
 /* Nonstandard routines */
 #ifndef _ANSI_SOURCE
-int	 bcmp __P((const void *, const void *, size_t));
-void	 bcopy __P((const void *, void *, size_t));
-void	 bzero __P((void *, size_t));
-int	 ffs __P((int));
-char	*index __P((const char *, int));
-void	*memccpy __P((void *, const void *, int, size_t));
-char	*rindex __P((const char *, int));
-int	 strcasecmp __P((const char *, const char *));
-char	*strdup __P((const char *));
+/* __BSD_VISIBLE */
+
+void	*memrchr __P((const void *, int, size_t));
+void	*memmem __P((const void *, size_t, const void *, size_t));
+char	*strcasestr __P((const char *, const char *));
+size_t	 strlcat __P((char *, const char *, size_t));
+size_t	 strlcpy __P((char *, const char *, size_t));
 void	 strmode __P((int, char *));
-int	 strncasecmp __P((const char *, const char *, size_t));
+char	*strnstr __P((const char *, const char *, size_t));
 char	*strsep __P((char **, const char *));
+
+#ifndef _SWAB_DECLARED
+#define _SWAB_DECLARED
 void	 swab __P((const void *, void *, size_t));
+#endif /* _SWAB_DECLARED */
 
 /* These are specific to Orca and GNO.  Some should probably use "const" */
 char 	*c2pstr __P((char *));

--- a/include/strings.h
+++ b/include/strings.h
@@ -1,0 +1,75 @@
+/*-
+ * Copyright (c) 2002 Mike Barcroft <mike@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef _STRINGS_H_
+#define	_STRINGS_H_
+
+//#include <sys/cdefs.h>
+//#include <sys/_types.h>
+
+#ifndef _MACHINE_ANSI_H_
+#include <machine/ansi.h>
+#endif
+
+#if defined(_BSD_SIZE_T_) && !defined(__size_t__)
+#define __size_t__ 1
+typedef	_BSD_SIZE_T_	size_t;
+#undef	_BSD_SIZE_T_
+#endif
+
+#ifndef	NULL
+#define NULL  (void *) 0L
+#endif
+
+#ifndef _SYS_CDEFS_H_
+#include <sys/cdefs.h>
+#endif
+
+__BEGIN_DECLS
+int	 bcmp(const void *, const void *, size_t) __pure;	/* LEGACY */
+void	 bcopy(const void *, void *, size_t);			/* LEGACY */
+void	 bzero(void *, size_t);					/* LEGACY */
+int	 ffs(int) __pure2;
+
+char	*index(const char *, int) __pure;			/* LEGACY */
+char	*rindex(const char *, int) __pure;			/* LEGACY */
+int	 strcasecmp(const char *, const char *) __pure;
+int	 strncasecmp(const char *, const char *, size_t) __pure;
+
+#ifndef _ANSI_SOURCE
+
+int	 ffsl(long) __pure2;
+//int	 ffsll(long long) __pure2;
+int	 fls(int) __pure2;
+int	 flsl(long) __pure2;
+//int	 flsll(long long) __pure2;
+
+#endif
+__END_DECLS
+
+#endif /* _STRINGS_H_ */

--- a/include/sys/cdefs.h
+++ b/include/sys/cdefs.h
@@ -109,4 +109,19 @@
 #define __pure2
 #define __attribute__(x)
 
+/*
+ * We use `__restrict' as a way to define the `restrict' type qualifier
+ * without disturbing older software that is unaware of C99 keywords.
+ */
+#if __STDC_VERSION__ < 199901
+#define __restrict
+#else
+#define __restrict      restrict
+#endif
+
+/* Source compatibility only, ID string not emitted in object file */
+#ifndef __FBSDID
+#define __FBSDID(s) struct __fbsdid_hack
+#endif
+
 #endif /* !_SYS_CDEFS_H_ */

--- a/lib/lib.mk
+++ b/lib/lib.mk
@@ -23,6 +23,11 @@
 	CFLAGS+= -G$(DEBUG)
 .END
 
+# check for a segment.
+.IF $(SEGMENT) != $(NULL)
+	CFLAGS+= -S $(SEGMENT)
+.END
+
 # Was special optimizing requested?
 OPTIMIZE*= 78
 

--- a/lib/libc/gen/Makefile
+++ b/lib/libc/gen/Makefile
@@ -8,7 +8,7 @@ LIB	= c
 LIBPFX	= $(OBJ_DIR)../
 NO_REZ	= true
 SRC_ASM	= setjmp.asm
-SRC_C	= basename.c bmem.c compat.c dirent.c err.c fnmatch.c fts.c \
+SRC_C	= basename.c compat.c dirent.c err.c errlist.c fnmatch.c fts.c \
 	  getcwd.c getgrent.c getlogin.c getpass.c getpwent.c \
 	  getttyent.c hostname.c \
 	  popen.c psignal.c pwcache.c scandir.c siglist.c sleep.c \

--- a/lib/libc/gen/errlist.c
+++ b/lib/libc/gen/errlist.c
@@ -1,0 +1,90 @@
+/*
+ * Implementation by Devin Reade.
+ *
+ * $Id: strerror.c,v 1.3 1998/02/04 15:16:19 gdr-ftp Exp $
+ *
+ * This file is formatted with tab stops every 8 columns.
+ */
+
+#ifdef __ORCAC__
+segment "libc_gen__";
+#endif
+
+#include <sys/errno.h>		/* for ELAST */
+
+const char * const sys_errlist[] = {
+
+/* the following are used by both GNO and the Orca/Shell */
+
+	"unknown error",			/*  0 */
+	"domain error",				/*  1 */
+	"result too large",			/*  2 */
+	"not enough memory",			/*  3 */
+	"no such file or directory",		/*  4 */
+	"I/O error",				/*  5 */
+	"invalid argument",			/*  6 */
+	"bad file descriptor",			/*  7 */
+	"too many open files",			/*  8 */
+	"permission denied",			/*  9 */
+	"file exists",				/* 10 */
+	"no space left on device",		/* 11 */
+
+/* the following are GNO-specific */
+
+	"operation not permitted",		/* 12 */
+	"no such process",			/* 13 */
+	"interrupted system call",		/* 14 */
+	"arg list too long",			/* 15 */
+	"exec format error",			/* 16 */
+	"no child processes",			/* 17 */
+	"resource unavailable",			/* 18 */
+	"not a directory",			/* 19 */
+	"inappropriate ioctl for device",	/* 20 */
+	"broken pipe",				/* 21 */
+	"illegal seek",				/* 22 */
+	"block device required",		/* 23 */
+	"is a directory",			/* 24 */
+	"not a socket",				/* 25 */
+	"destination address required",		/* 26 */
+	"message too long",			/* 27 */
+	"wrong protocol for socket",		/* 28 */
+	"protocol not available",		/* 29 */
+	"protocol not supported",		/* 30 */
+	"socket type not supported",		/* 31 */
+	"operation not supported on socket",	/* 32 */
+	"protocol family not supported",	/* 33 */
+	"address family not supported",		/* 34 */
+	"address already in use",		/* 35 */
+	"can't assign requested address",	/* 36 */
+	"network is down",			/* 37 */
+	"network is unreachable",		/* 38 */
+	"network dropped connection on reset",	/* 39 */
+	"connection aborted",			/* 40 */
+	"connection reset by peer",		/* 41 */
+	"no buffer space available",		/* 42 */
+	"socket is already connected",		/* 43 */
+	"socket is not connected",		/* 44 */
+	"can't send after socket shutdown",	/* 45 */
+	"too many references: can't splice",	/* 46 */
+	"connection timed out",			/* 47 */
+	"connection refused",			/* 48 */
+	"operation would block",		/* 49 */
+	"operation now in progress",		/* 50 */
+	"operation already in progress",	/* 51 */
+	"bad address",				/* 52 */
+	"no such device",			/* 53 */
+	"host is down",				/* 54 */
+	"no route to host",			/* 55 */
+#define SYS_NERR 56	/* 55 + 1 for zeroth entry */
+};
+
+#if (ELAST + 1 != SYS_NERR)
+#error message table out of sync
+#endif
+
+const int
+sys_nerr = SYS_NERR;
+
+const char * const *
+_errnoText = sys_errlist;	/* backward compatible */
+

--- a/lib/libc/gen/siglist.c
+++ b/lib/libc/gen/siglist.c
@@ -115,3 +115,5 @@ const char *const sys_siglist[NSIG] = {
 	"User defined signal 1",	/* SIGUSR1 */
 	"User defined signal 2"		/* SIGUSR2 */
 };
+
+const int sys_nsig = NSIG;

--- a/lib/libc/string/Makefile
+++ b/lib/libc/string/Makefile
@@ -7,6 +7,13 @@
 LIB	= c
 LIBPFX	= $(OBJ_DIR)../
 NO_REZ	= true
-SRCS	= case.c str.c strerror.c swab.c
+SEGMENT	= libc_str__
+SRCS	= bmem.c case.c ffs.c ffsl.c fls.c flsl.c \
+	  memccpy.c memmem.c memrchr.c \
+	  stpcpy.c stpncpy.c str.c strcasestr.c \
+	  strerror.c strlcat.c strlcpy.c strmode.c \
+	  strndup.c strnlen.c strnstr.c strsignal.c \
+	  strtok.c swab.c
+	  
 
 .INCLUDE: /src/gno/lib/lib.mk

--- a/lib/libc/string/bmem.c
+++ b/lib/libc/string/bmem.c
@@ -4,10 +4,6 @@
  * This file is formatted with tabs every 8 columns.
  */
 
-#ifdef __ORCAC__
-segment "libc_gen__";
-#endif
-
 #include <string.h>
 
 void
@@ -18,4 +14,10 @@ bzero(void *buf, size_t len) {
 void
 bcopy(const void *src, const void *dest, size_t len) {
 	memmove(dest, src, len);
+}
+
+
+int
+bcmp(const void *s1, const void *s2, size_t len) {
+	memcmp(s1, s2, len);
 }

--- a/lib/libc/string/case.c
+++ b/lib/libc/string/case.c
@@ -6,10 +6,6 @@
  * This file is formatted with tab stops every 8 columns.
  */
 
-#ifdef __ORCAC__
-segment "libc_str__";
-#endif
-
 #include <string.h>
 #include <ctype.h>
 

--- a/lib/libc/string/ffs.c
+++ b/lib/libc/string/ffs.c
@@ -1,9 +1,6 @@
-/*
- * Copyright (c) 1988, 1993
+/*-
+ * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
- *
- * This code is derived from software contributed to Berkeley by
- * Jeffrey Mogul.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,107 +28,51 @@
  */
 
 #if defined(LIBC_SCCS) && !defined(lint)
-static char sccsid[] = "@(#)swab.c	8.1 (Berkeley) 6/4/93";
+static char sccsid[] = "@(#)ffs.c	8.1 (Berkeley) 6/4/93";
 #endif /* LIBC_SCCS and not lint */
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
-#include <unistd.h>
+#include <strings.h>
 
 #ifdef __ORCAC__
 
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
+int
+ffs(int mask)
 {
+	int bit;
 
 	asm {
-
 		ldy #0
-
-		// if (len < 0) return;
-
-		ldx <len+2	// number of banks
-		bmi done
-		beq partial
-
-bloop:
-		// partially unrolled - 8 bytes at a time.
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		bne bloop
-
-		dex	// # of banks
-		beq partial
-		inc <from+2
-		inc <to+2
-		bra bloop
-
-partial:
-		lda <len
-		lsr a
+		lda <mask
 		beq done
-
-		tax
-
-		ldy #0
-ploop:
-		lda [from],y
-		xba
-		sta [to],y
+loop:
 		iny
-		iny
-		dex
-		bne ploop
-
+		lsr a
+		bcc loop
 done:
+		sty <bit
 	}
 
+	return bit;
 }
 
 
 #else
 
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
+/*
+ * Find First Set bit
+ */
+int
+ffs(int mask)
 {
-	unsigned long temp;
-	int n;
-	char *fp, *tp;
+	int bit;
 
-	if (len <= 0)
-		return;
-	n = len >> 1;
-	fp = (char *)from;
-	tp = (char *)to;
-#define	STEP	temp = *fp++,*tp++ = *fp++,*tp++ = temp
-	/* round to multiple of 8 */
-	for (; n & 0x7; --n)
-		STEP;
-	for (n >>= 3; n > 0; --n) {
-		STEP; STEP; STEP; STEP;
-		STEP; STEP; STEP; STEP;
-	}
+	if (mask == 0)
+		return(0);
+	for (bit = 1; !(mask & 1); bit++)
+		mask = (unsigned int)mask >> 1;
+	return (bit);
 }
+
 #endif

--- a/lib/libc/string/ffsl.c
+++ b/lib/libc/string/ffsl.c
@@ -1,9 +1,6 @@
-/*
- * Copyright (c) 1988, 1993
+/*-
+ * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
- *
- * This code is derived from software contributed to Berkeley by
- * Jeffrey Mogul.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,108 +27,53 @@
  * SUCH DAMAGE.
  */
 
-#if defined(LIBC_SCCS) && !defined(lint)
-static char sccsid[] = "@(#)swab.c	8.1 (Berkeley) 6/4/93";
-#endif /* LIBC_SCCS and not lint */
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
-#include <unistd.h>
+#include <strings.h>
+
 
 #ifdef __ORCAC__
 
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
+int
+ffsl(long mask)
 {
+	int bit;
 
 	asm {
-
 		ldy #0
-
-		// if (len < 0) return;
-
-		ldx <len+2	// number of banks
-		bmi done
-		beq partial
-
-bloop:
-		// partially unrolled - 8 bytes at a time.
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		bne bloop
-
-		dex	// # of banks
-		beq partial
-		inc <from+2
-		inc <to+2
-		bra bloop
-
-partial:
-		lda <len
-		lsr a
+		lda <mask
+		bne loop
+high:
+		lda <mask+2
 		beq done
-
-		tax
-
-		ldy #0
-ploop:
-		lda [from],y
-		xba
-		sta [to],y
+		ldy #16
+loop:
 		iny
-		iny
-		dex
-		bne ploop
-
+		lsr a
+		bcc loop
 done:
+		sty <bit
+
 	}
 
+	return bit;
 }
-
 
 #else
-
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
+/*
+ * Find First Set bit
+ */
+int
+ffsl(long mask)
 {
-	unsigned long temp;
-	int n;
-	char *fp, *tp;
+	int bit;
 
-	if (len <= 0)
-		return;
-	n = len >> 1;
-	fp = (char *)from;
-	tp = (char *)to;
-#define	STEP	temp = *fp++,*tp++ = *fp++,*tp++ = temp
-	/* round to multiple of 8 */
-	for (; n & 0x7; --n)
-		STEP;
-	for (n >>= 3; n > 0; --n) {
-		STEP; STEP; STEP; STEP;
-		STEP; STEP; STEP; STEP;
-	}
+	if (mask == 0)
+		return (0);
+	for (bit = 1; !(mask & 1); bit++)
+		mask = (unsigned long)mask >> 1;
+	return (bit);
 }
+
 #endif

--- a/lib/libc/string/fls.c
+++ b/lib/libc/string/fls.c
@@ -1,9 +1,6 @@
-/*
- * Copyright (c) 1988, 1993
+/*-
+ * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
- *
- * This code is derived from software contributed to Berkeley by
- * Jeffrey Mogul.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,108 +27,48 @@
  * SUCH DAMAGE.
  */
 
-#if defined(LIBC_SCCS) && !defined(lint)
-static char sccsid[] = "@(#)swab.c	8.1 (Berkeley) 6/4/93";
-#endif /* LIBC_SCCS and not lint */
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
-#include <unistd.h>
+#include <strings.h>
 
 #ifdef __ORCAC__
 
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
+int
+fls(int mask)
 {
+	int bit;
 
 	asm {
-
 		ldy #0
-
-		// if (len < 0) return;
-
-		ldx <len+2	// number of banks
-		bmi done
-		beq partial
-
-bloop:
-		// partially unrolled - 8 bytes at a time.
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		bne bloop
-
-		dex	// # of banks
-		beq partial
-		inc <from+2
-		inc <to+2
-		bra bloop
-
-partial:
-		lda <len
-		lsr a
+		lda <mask
 		beq done
-
-		tax
-
-		ldy #0
-ploop:
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-		dex
-		bne ploop
-
+loop:
+		dey
+		lsr a
+		bne loop
 done:
+		sty <bit
 	}
 
+	return bit;
 }
-
 
 #else
 
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
+/*
+ * Find Last Set bit
+ */
+int
+fls(int mask)
 {
-	unsigned long temp;
-	int n;
-	char *fp, *tp;
+	int bit;
 
-	if (len <= 0)
-		return;
-	n = len >> 1;
-	fp = (char *)from;
-	tp = (char *)to;
-#define	STEP	temp = *fp++,*tp++ = *fp++,*tp++ = temp
-	/* round to multiple of 8 */
-	for (; n & 0x7; --n)
-		STEP;
-	for (n >>= 3; n > 0; --n) {
-		STEP; STEP; STEP; STEP;
-		STEP; STEP; STEP; STEP;
-	}
+	if (mask == 0)
+		return (0);
+	for (bit = 1; mask != 1; bit++)
+		mask = (unsigned int)mask >> 1;
+	return (bit);
 }
+
 #endif

--- a/lib/libc/string/flsl.c
+++ b/lib/libc/string/flsl.c
@@ -1,9 +1,6 @@
-/*
- * Copyright (c) 1988, 1993
+/*-
+ * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
- *
- * This code is derived from software contributed to Berkeley by
- * Jeffrey Mogul.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,108 +27,54 @@
  * SUCH DAMAGE.
  */
 
-#if defined(LIBC_SCCS) && !defined(lint)
-static char sccsid[] = "@(#)swab.c	8.1 (Berkeley) 6/4/93";
-#endif /* LIBC_SCCS and not lint */
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
-#include <unistd.h>
+#include <strings.h>
 
 #ifdef __ORCAC__
 
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
+int
+flsl(long mask)
 {
+	int bit;
 
 	asm {
-
+		ldy #16
+		lda <mask+2
+		bne loop
+low:
 		ldy #0
-
-		// if (len < 0) return;
-
-		ldx <len+2	// number of banks
-		bmi done
-		beq partial
-
-bloop:
-		// partially unrolled - 8 bytes at a time.
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		bne bloop
-
-		dex	// # of banks
-		beq partial
-		inc <from+2
-		inc <to+2
-		bra bloop
-
-partial:
-		lda <len
-		lsr a
+		lda <mask
 		beq done
-
-		tax
-
-		ldy #0
-ploop:
-		lda [from],y
-		xba
-		sta [to],y
+loop:
 		iny
-		iny
-		dex
-		bne ploop
-
+		lsr a
+		bne loop
 done:
+		sty <bit
+
 	}
 
+	return bit;
 }
 
 
 #else
 
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
+/*
+ * Find Last Set bit
+ */
+int
+flsl(long mask)
 {
-	unsigned long temp;
-	int n;
-	char *fp, *tp;
+	int bit;
 
-	if (len <= 0)
-		return;
-	n = len >> 1;
-	fp = (char *)from;
-	tp = (char *)to;
-#define	STEP	temp = *fp++,*tp++ = *fp++,*tp++ = temp
-	/* round to multiple of 8 */
-	for (; n & 0x7; --n)
-		STEP;
-	for (n >>= 3; n > 0; --n) {
-		STEP; STEP; STEP; STEP;
-		STEP; STEP; STEP; STEP;
-	}
+	if (mask == 0)
+		return (0);
+	for (bit = 1; mask != 1; bit++)
+		mask = (unsigned long)mask >> 1;
+	return (bit);
 }
+
 #endif

--- a/lib/libc/string/memccpy.c
+++ b/lib/libc/string/memccpy.c
@@ -1,9 +1,6 @@
-/*
- * Copyright (c) 1988, 1993
+/*-
+ * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
- *
- * This code is derived from software contributed to Berkeley by
- * Jeffrey Mogul.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,107 +28,25 @@
  */
 
 #if defined(LIBC_SCCS) && !defined(lint)
-static char sccsid[] = "@(#)swab.c	8.1 (Berkeley) 6/4/93";
+static char sccsid[] = "@(#)memccpy.c	8.1 (Berkeley) 6/4/93";
 #endif /* LIBC_SCCS and not lint */
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
-#include <unistd.h>
+#include <string.h>
 
-#ifdef __ORCAC__
-
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
+void *
+memccpy(void *t, const void *f, int c, size_t n)
 {
 
-	asm {
-
-		ldy #0
-
-		// if (len < 0) return;
-
-		ldx <len+2	// number of banks
-		bmi done
-		beq partial
-
-bloop:
-		// partially unrolled - 8 bytes at a time.
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		bne bloop
-
-		dex	// # of banks
-		beq partial
-		inc <from+2
-		inc <to+2
-		bra bloop
-
-partial:
-		lda <len
-		lsr a
-		beq done
-
-		tax
-
-		ldy #0
-ploop:
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-		dex
-		bne ploop
-
-done:
+	if (n) {
+		unsigned char *tp = (unsigned char *)t;
+		const unsigned char *fp = (const unsigned char *)f;
+		unsigned char uc = c;
+		do {
+			if ((*tp++ = *fp++) == uc)
+				return (tp);
+		} while (--n != 0);
 	}
-
+	return (0);
 }
-
-
-#else
-
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
-{
-	unsigned long temp;
-	int n;
-	char *fp, *tp;
-
-	if (len <= 0)
-		return;
-	n = len >> 1;
-	fp = (char *)from;
-	tp = (char *)to;
-#define	STEP	temp = *fp++,*tp++ = *fp++,*tp++ = temp
-	/* round to multiple of 8 */
-	for (; n & 0x7; --n)
-		STEP;
-	for (n >>= 3; n > 0; --n) {
-		STEP; STEP; STEP; STEP;
-		STEP; STEP; STEP; STEP;
-	}
-}
-#endif

--- a/lib/libc/string/memmem.c
+++ b/lib/libc/string/memmem.c
@@ -1,0 +1,65 @@
+/*-
+ * Copyright (c) 2005 Pascal Gloor <pascal.gloor@spale.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior written
+ *    permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <string.h>
+
+/*
+ * Find the first occurrence of the byte string s in byte string l.
+ */
+
+void *
+memmem(const void *l, size_t l_len, const void *s, size_t s_len)
+{
+	register char *cur, *last;
+	const char *cl = (const char *)l;
+	const char *cs = (const char *)s;
+
+	/* we need something to compare */
+	if (l_len == 0 || s_len == 0)
+		return NULL;
+
+	/* "s" must be smaller or equal to "l" */
+	if (l_len < s_len)
+		return NULL;
+
+	/* special case where s_len == 1 */
+	if (s_len == 1)
+		return memchr(l, (int)*cs, l_len);
+
+	/* the last position where its possible to find "s" in "l" */
+	last = (char *)cl + l_len - s_len;
+
+	for (cur = (char *)cl; cur <= last; cur++)
+		if (cur[0] == cs[0] && memcmp((const void *)cur, (const void *)cs, s_len) == 0)
+			return cur;
+
+	return NULL;
+}

--- a/lib/libc/string/memrchr.c
+++ b/lib/libc/string/memrchr.c
@@ -1,0 +1,40 @@
+/*	$OpenBSD: memrchr.c,v 1.2 2007/11/27 16:22:12 martynas Exp $	*/
+
+/*
+ * Copyright (c) 2007 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * $FreeBSD$
+ */
+
+#include <string.h>
+
+/*
+ * Reverse memchr()
+ * Find the last occurrence of 'c' in the buffer 's' of size 'n'.
+ */
+void *
+memrchr(const void *s, int c, size_t n)
+{
+	const unsigned char *cp;
+
+	if (n != 0) {
+		cp = (unsigned char *)s + n;
+		do {
+			if (*(--cp) == (unsigned char)c)
+				return((void *)cp);
+		} while (--n != 0);
+	}
+	return(NULL);
+}

--- a/lib/libc/string/missing.text
+++ b/lib/libc/string/missing.text
@@ -1,0 +1,5 @@
+strcoll (locale)
+strxfrm (locale)
+
+ffsll (long long)
+flsll (long long)

--- a/lib/libc/string/stpncpy.c
+++ b/lib/libc/string/stpncpy.c
@@ -1,0 +1,158 @@
+/*-
+ * Copyright (c) 2009 David Schultz <das@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <string.h>
+
+#ifdef __XXORCAC__
+
+char *
+stpncpy(char * __restrict dst, const char * __restrict src, size_t n)
+{
+	#define LONG_M rep #0x20
+	#define SHORT_M sep #0x20
+
+
+	// copy at most n characters.
+	// if strlen(src) < n, zero-fill the remainder (but return ptr to first null)
+
+	asm {
+
+		SHORT_M
+		ldy #0
+		ldx <n+2 	// max # of banks to copy
+		beq partial
+
+		// potentially copy a full bank.
+bloop:
+		// partially unrolled, factor = 4
+		lda [src],y
+		sta [dest],y
+		beq done
+		iny
+
+		lda [src],y
+		sta [dest],y
+		beq done
+		iny
+
+		lda [src],y
+		sta [dest],y
+		beq done
+		iny
+
+		lda [src],y
+		sta [dest],y
+		beq done
+		iny
+
+
+		bne bloop
+
+		inc <src+2
+		inc <dest+2
+		dec <n+2
+		dex
+		bne bloop
+
+partial:
+		// copy a partial bank
+		ldy #0
+		ldx <n
+		beq maxn
+ploop:
+		lda [src],y
+		sta [dest],y
+		beq done
+		iny
+		dex
+		bne ploop
+	
+maxn:	
+		// at this point, n bytes have been copied and no NULL was found.
+		// if stpncpy does not terminate with a NULL, it returns dst+n
+
+		// n+2 is 0.
+		LONG_M
+		clc
+		lda <n
+		adc <dst
+		sta <dst
+		lda #0
+		adc <dst+2
+		sta <dst+2
+		stz <n
+		stz <n+2 // will already be 0.
+		bra r 
+
+done:
+		// at this point, a NULL character was found
+		// however, dest[y+1].. dest[n-1] must be 0 filled.
+		LONG_M
+		tya
+		clc
+		adc <dst
+		sta <dst
+		lda #0
+		adc <dst+2
+		sta <dst+2
+
+		// update n for bzero.
+		sec
+		tya
+		sbc <n
+		sta <n
+		sbc <n+2
+		sta <n+2
+
+r:
+	}
+
+	// really only need to do this if n > 1
+	if (n) bzero(dst, n);
+	return dst;
+}
+
+#else
+
+char *
+stpncpy(char * __restrict dst, const char * __restrict src, size_t n)
+{
+
+	for (; n--; dst++, src++) {
+		if (!(*dst = *src)) {
+			char *ret = dst;
+			while (n--)
+				*++dst = '\0';
+			return (ret);
+		}
+	}
+	return (dst);
+}
+
+#endif

--- a/lib/libc/string/str.c
+++ b/lib/libc/string/str.c
@@ -9,10 +9,6 @@
  * This file is formatted with tabs in every 8 columns.
  */
 
-#ifdef __ORCAC__
-segment "libc_str__";
-#endif
-
 #include <stdlib.h>
 #include <string.h>
 

--- a/lib/libc/string/strcasestr.c
+++ b/lib/libc/string/strcasestr.c
@@ -1,9 +1,9 @@
-/*
- * Copyright (c) 1988, 1993
+/*-
+ * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
  *
  * This code is derived from software contributed to Berkeley by
- * Jeffrey Mogul.
+ * Chris Torek.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,108 +30,31 @@
  * SUCH DAMAGE.
  */
 
-#if defined(LIBC_SCCS) && !defined(lint)
-static char sccsid[] = "@(#)swab.c	8.1 (Berkeley) 6/4/93";
-#endif /* LIBC_SCCS and not lint */
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
-#include <unistd.h>
+#include <ctype.h>
+#include <string.h>
 
-#ifdef __ORCAC__
-
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
+/*
+ * Find the first occurrence of find in s, ignore case.
+ */
+char *
+strcasestr(const char *s, const char *find)
 {
+	char c, sc;
+	size_t len;
 
-	asm {
-
-		ldy #0
-
-		// if (len < 0) return;
-
-		ldx <len+2	// number of banks
-		bmi done
-		beq partial
-
-bloop:
-		// partially unrolled - 8 bytes at a time.
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		bne bloop
-
-		dex	// # of banks
-		beq partial
-		inc <from+2
-		inc <to+2
-		bra bloop
-
-partial:
-		lda <len
-		lsr a
-		beq done
-
-		tax
-
-		ldy #0
-ploop:
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-		dex
-		bne ploop
-
-done:
+	if ((c = *find++) != 0) {
+		c = tolower((unsigned char)c);
+		len = strlen(find);
+		do {
+			do {
+				if ((sc = *s++) == 0)
+					return (NULL);
+			} while ((char)tolower((unsigned char)sc) != c);
+		} while (strncasecmp(s, find, len) != 0);
+		s--;
 	}
-
+	return ((char *)s);
 }
-
-
-#else
-
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
-{
-	unsigned long temp;
-	int n;
-	char *fp, *tp;
-
-	if (len <= 0)
-		return;
-	n = len >> 1;
-	fp = (char *)from;
-	tp = (char *)to;
-#define	STEP	temp = *fp++,*tp++ = *fp++,*tp++ = temp
-	/* round to multiple of 8 */
-	for (; n & 0x7; --n)
-		STEP;
-	for (n >>= 3; n > 0; --n) {
-		STEP; STEP; STEP; STEP;
-		STEP; STEP; STEP; STEP;
-	}
-}
-#endif

--- a/lib/libc/string/strlcat.c
+++ b/lib/libc/string/strlcat.c
@@ -1,0 +1,58 @@
+/*	$OpenBSD: strlcat.c,v 1.13 2005/08/08 08:05:37 espie Exp $	*/
+
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Appends src to string dst of size siz (unlike strncat, siz is the
+ * full size of dst, not space left).  At most siz-1 characters
+ * will be copied.  Always NUL terminates (unless siz <= strlen(dst)).
+ * Returns strlen(src) + MIN(siz, strlen(initial dst)).
+ * If retval >= siz, truncation occurred.
+ */
+size_t
+strlcat(char * __restrict dst, const char * __restrict src, size_t siz)
+{
+	char *d = dst;
+	const char *s = src;
+	size_t n = siz;
+	size_t dlen;
+
+	/* Find the end of dst and adjust bytes left but don't go past end */
+	while (n-- != 0 && *d != '\0')
+		d++;
+	dlen = d - dst;
+	n = siz - dlen;
+
+	if (n == 0)
+		return(dlen + strlen(s));
+	while (*s != '\0') {
+		if (n != 1) {
+			*d++ = *s;
+			n--;
+		}
+		s++;
+	}
+	*d = '\0';
+
+	return(dlen + (s - src));	/* count does not include NUL */
+}

--- a/lib/libc/string/strlcpy.c
+++ b/lib/libc/string/strlcpy.c
@@ -1,0 +1,54 @@
+/*	$OpenBSD: strlcpy.c,v 1.11 2006/05/05 15:27:38 millert Exp $	*/
+
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/types.h>
+#include <string.h>
+
+/*
+ * Copy src to string dst of size siz.  At most siz-1 characters
+ * will be copied.  Always NUL terminates (unless siz == 0).
+ * Returns strlen(src); if retval >= siz, truncation occurred.
+ */
+size_t
+strlcpy(char * __restrict dst, const char * __restrict src, size_t siz)
+{
+	char *d = dst;
+	const char *s = src;
+	size_t n = siz;
+
+	/* Copy as many bytes as will fit */
+	if (n != 0) {
+		while (--n != 0) {
+			if ((*d++ = *s++) == '\0')
+				break;
+		}
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src */
+	if (n == 0) {
+		if (siz != 0)
+			*d = '\0';		/* NUL-terminate dst */
+		while (*s++)
+			;
+	}
+
+	return(s - src - 1);	/* count does not include NUL */
+}

--- a/lib/libc/string/strmode.c
+++ b/lib/libc/string/strmode.c
@@ -1,0 +1,148 @@
+/*-
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#if defined(LIBC_SCCS) && !defined(lint)
+static char sccsid[] = "@(#)strmode.c	8.3 (Berkeley) 8/15/94";
+#endif /* LIBC_SCCS and not lint */
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <string.h>
+
+void
+strmode(/* mode_t */ int mode, char *p)
+{
+	 /* print type */
+	switch (mode & S_IFMT) {
+	case S_IFDIR:			/* directory */
+		*p++ = 'd';
+		break;
+	case S_IFCHR:			/* character special */
+		*p++ = 'c';
+		break;
+	case S_IFBLK:			/* block special */
+		*p++ = 'b';
+		break;
+	case S_IFREG:			/* regular */
+		*p++ = '-';
+		break;
+	case S_IFLNK:			/* symbolic link */
+		*p++ = 'l';
+		break;
+	case S_IFSOCK:			/* socket */
+		*p++ = 's';
+		break;
+#ifdef S_IFIFO
+	case S_IFIFO:			/* fifo */
+		*p++ = 'p';
+		break;
+#endif
+#ifdef S_IFWHT
+	case S_IFWHT:			/* whiteout */
+		*p++ = 'w';
+		break;
+#endif
+	default:			/* unknown */
+		*p++ = '?';
+		break;
+	}
+	/* usr */
+	if (mode & S_IRUSR)
+		*p++ = 'r';
+	else
+		*p++ = '-';
+	if (mode & S_IWUSR)
+		*p++ = 'w';
+	else
+		*p++ = '-';
+	switch (mode & (S_IXUSR | S_ISUID)) {
+	case 0:
+		*p++ = '-';
+		break;
+	case S_IXUSR:
+		*p++ = 'x';
+		break;
+	case S_ISUID:
+		*p++ = 'S';
+		break;
+	case S_IXUSR | S_ISUID:
+		*p++ = 's';
+		break;
+	}
+	/* group */
+	if (mode & S_IRGRP)
+		*p++ = 'r';
+	else
+		*p++ = '-';
+	if (mode & S_IWGRP)
+		*p++ = 'w';
+	else
+		*p++ = '-';
+	switch (mode & (S_IXGRP | S_ISGID)) {
+	case 0:
+		*p++ = '-';
+		break;
+	case S_IXGRP:
+		*p++ = 'x';
+		break;
+	case S_ISGID:
+		*p++ = 'S';
+		break;
+	case S_IXGRP | S_ISGID:
+		*p++ = 's';
+		break;
+	}
+	/* other */
+	if (mode & S_IROTH)
+		*p++ = 'r';
+	else
+		*p++ = '-';
+	if (mode & S_IWOTH)
+		*p++ = 'w';
+	else
+		*p++ = '-';
+	switch (mode & (S_IXOTH | S_ISVTX)) {
+	case 0:
+		*p++ = '-';
+		break;
+	case S_IXOTH:
+		*p++ = 'x';
+		break;
+	case S_ISVTX:
+		*p++ = 'T';
+		break;
+	case S_IXOTH | S_ISVTX:
+		*p++ = 't';
+		break;
+	}
+	*p++ = ' ';
+	*p = '\0';
+}

--- a/lib/libc/string/strnlen.c
+++ b/lib/libc/string/strnlen.c
@@ -1,0 +1,143 @@
+/*-
+ * Copyright (c) 2009 David Schultz <das@FreeBSD.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <string.h>
+
+#ifdef __ORCAC__
+
+#define SHORTM sep #0x20
+#define LONGM rep #0x20
+#define SHORTX sep #0x10
+#define LONGX rep #0x10
+#define SHORTMX sep #0x30
+#define LONGMX rep #0x30
+
+
+size_t
+strnlen(const char *s, size_t maxlen)
+{
+	size_t len;
+
+	asm {
+		stz <len
+		stz <len+2
+
+		ldy #0
+		ldx <maxlen+2 // # of banks
+		beq partial
+
+		ldy #0
+		// handle a full bank.  this is done 2-bytes at a time
+bloop:
+		lda [s],y
+		bit #0x00ff
+		beq done
+		iny
+
+		bit #0xff00
+		beq done
+		iny
+
+		// partially unrolled.
+		lda [s],y
+		bit #0x00ff
+		beq done
+		iny
+
+		bit #0xff00
+		beq done
+		iny
+
+		// 3
+		lda [s],y
+		bit #0x00ff
+		beq done
+		iny
+
+		bit #0xff00
+		beq done
+		iny	
+
+		// 4
+		lda [s],y
+		bit #0x00ff
+		beq done
+		iny
+
+		bit #0xff00
+		beq done
+		iny
+
+		bne bloop
+		inc <s+2
+		inc <len+2
+		dex
+		bne bloop
+
+
+partial:	// handle a partial bank.  This is done byte-by-byte.
+		ldy #0
+		ldx <maxlen
+		beq done
+
+		SHORTM
+ploop:
+		lda [s],y
+		beq done
+		iny
+		dex
+		bne ploop
+		LONGM
+
+
+done:
+		sty <len
+
+	}
+
+
+	return (len);
+}
+
+
+#else
+
+size_t
+strnlen(const char *s, size_t maxlen)
+{
+	size_t len;
+
+	for (len = 0; len < maxlen; len++, s++) {
+		if (!*s)
+			break;
+	}
+	return (len);
+}
+
+#endif

--- a/lib/libc/string/strnstr.c
+++ b/lib/libc/string/strnstr.c
@@ -1,9 +1,10 @@
-/*
- * Copyright (c) 1988, 1993
+/*-
+ * Copyright (c) 2001 Mike Barcroft <mike@FreeBSD.org>
+ * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
  *
  * This code is derived from software contributed to Berkeley by
- * Jeffrey Mogul.
+ * Chris Torek.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,107 +32,34 @@
  */
 
 #if defined(LIBC_SCCS) && !defined(lint)
-static char sccsid[] = "@(#)swab.c	8.1 (Berkeley) 6/4/93";
+static char sccsid[] = "@(#)strstr.c	8.1 (Berkeley) 6/4/93";
 #endif /* LIBC_SCCS and not lint */
 #include <sys/cdefs.h>
 __FBSDID("$FreeBSD$");
 
-#include <unistd.h>
+#include <string.h>
 
-#ifdef __ORCAC__
-
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
+/*
+ * Find the first occurrence of find in s, where the search is limited to the
+ * first slen characters of s.
+ */
+char *
+strnstr(const char *s, const char *find, size_t slen)
 {
+	char c, sc;
+	size_t len;
 
-	asm {
-
-		ldy #0
-
-		// if (len < 0) return;
-
-		ldx <len+2	// number of banks
-		bmi done
-		beq partial
-
-bloop:
-		// partially unrolled - 8 bytes at a time.
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-
-		bne bloop
-
-		dex	// # of banks
-		beq partial
-		inc <from+2
-		inc <to+2
-		bra bloop
-
-partial:
-		lda <len
-		lsr a
-		beq done
-
-		tax
-
-		ldy #0
-ploop:
-		lda [from],y
-		xba
-		sta [to],y
-		iny
-		iny
-		dex
-		bne ploop
-
-done:
+	if ((c = *find++) != '\0') {
+		len = strlen(find);
+		do {
+			do {
+				if (slen-- < 1 || (sc = *s++) == '\0')
+					return (NULL);
+			} while (sc != c);
+			if (len > slen)
+				return (NULL);
+		} while (strncmp(s, find, len) != 0);
+		s--;
 	}
-
+	return ((char *)s);
 }
-
-
-#else
-
-void
-swab(const void * __restrict from, void * __restrict to, ssize_t len)
-{
-	unsigned long temp;
-	int n;
-	char *fp, *tp;
-
-	if (len <= 0)
-		return;
-	n = len >> 1;
-	fp = (char *)from;
-	tp = (char *)to;
-#define	STEP	temp = *fp++,*tp++ = *fp++,*tp++ = temp
-	/* round to multiple of 8 */
-	for (; n & 0x7; --n)
-		STEP;
-	for (n >>= 3; n > 0; --n) {
-		STEP; STEP; STEP; STEP;
-		STEP; STEP; STEP; STEP;
-	}
-}
-#endif

--- a/lib/libc/string/strtok.c
+++ b/lib/libc/string/strtok.c
@@ -1,0 +1,136 @@
+/*-
+ * Copyright (c) 1998 Softweyr LLC.  All rights reserved.
+ *
+ * strtok_r, from Berkeley strtok
+ * Oct 13, 1998 by Wes Peters <wes@softweyr.com>
+ *
+ * Copyright (c) 1988, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notices, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notices, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY SOFTWEYR LLC, THE REGENTS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL SOFTWEYR LLC, THE
+ * REGENTS, OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if defined(LIBC_SCCS) && !defined(lint)
+static char sccsid[] = "@(#)strtok.c	8.1 (Berkeley) 6/4/93";
+#endif /* LIBC_SCCS and not lint */
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <stddef.h>
+#ifdef DEBUG_STRTOK
+#include <stdio.h>
+#endif
+#include <string.h>
+
+
+char *
+strtok_r(char *s, const char *delim, char **last)
+{
+	char *spanp, *tok;
+	int c, sc;
+
+	if (s == NULL && (s = *last) == NULL)
+		return (NULL);
+
+	/*
+	 * Skip (span) leading delimiters (s += strspn(s, delim), sort of).
+	 */
+cont:
+	c = *s++;
+	for (spanp = (char *)delim; (sc = *spanp++) != 0;) {
+		if (c == sc)
+			goto cont;
+	}
+
+	if (c == 0) {		/* no non-delimiter characters */
+		*last = NULL;
+		return (NULL);
+	}
+	tok = s - 1;
+
+	/*
+	 * Scan token (scan for delimiters: s += strcspn(s, delim), sort of).
+	 * Note that delim must have one NUL; we stop if we see that, too.
+	 */
+	for (;;) {
+		c = *s++;
+		spanp = (char *)delim;
+		do {
+			if ((sc = *spanp++) == c) {
+				if (c == 0)
+					s = NULL;
+				else
+					s[-1] = '\0';
+				*last = s;
+				return (tok);
+			}
+		} while (sc != 0);
+	}
+	/* NOTREACHED */
+}
+
+/* strtok is implemented in orca's libc */
+#ifndef __ORCAC__
+char *
+strtok(char *s, const char *delim)
+{
+	static char *last;
+
+	return (__strtok_r(s, delim, &last));
+}
+#endif
+
+#ifdef DEBUG_STRTOK
+/*
+ * Test the tokenizer.
+ */
+int
+main(void)
+{
+	char blah[80], test[80];
+	char *brkb, *brkt, *phrase, *sep, *word;
+
+	sep = "\\/:;=-";
+	phrase = "foo";
+
+	printf("String tokenizer test:\n");
+	strcpy(test, "This;is.a:test:of=the/string\\tokenizer-function.");
+	for (word = strtok(test, sep); word; word = strtok(NULL, sep))
+		printf("Next word is \"%s\".\n", word);
+	strcpy(test, "This;is.a:test:of=the/string\\tokenizer-function.");
+
+	for (word = strtok_r(test, sep, &brkt); word;
+	    word = strtok_r(NULL, sep, &brkt)) {
+		strcpy(blah, "blah:blat:blab:blag");
+
+		for (phrase = strtok_r(blah, sep, &brkb); phrase;
+		    phrase = strtok_r(NULL, sep, &brkb))
+			printf("So far we're at %s:%s\n", word, phrase);
+	}
+
+	return (0);
+}
+
+#endif /* DEBUG_STRTOK */

--- a/lib/libc/tests/string/ffs.c
+++ b/lib/libc/tests/string/ffs.c
@@ -1,0 +1,48 @@
+#include <strings.h>
+#include <stdio.h>
+
+#define TEST(fx, input, expected) {\
+	int result = fx(input); \
+	if (result != expected) { \
+		fprintf(stderr, "%s(0x%04x): %d != %d\n",  #fx, input, result, expected);\
+		errors++;\
+	} \
+}
+
+#define TESTL(fx, input, expected) {\
+	int result = fx(input); \
+	if (result != expected) { \
+		fprintf(stderr, "%s(0x%08lx): %d != %d\n", #fx, (long)input, result, expected);\
+		errors++;\
+	} \
+}
+
+int main(int argc, char **argv)
+{
+	int errors = 0;
+	TEST(ffs, 0x0000, 0);
+	TEST(ffs, 0x0001, 1);
+	TEST(ffs, 0xff00, 9);
+	TEST(ffs, 0x8000, 16);
+
+	TESTL(ffsl, 0x00000000, 0);
+	TESTL(ffsl, 0x00000001, 1);
+	TESTL(ffsl, 0x00008000, 16);
+	TESTL(ffsl, 0x00010000, 17);
+	TESTL(ffsl, 0x80000000, 32);
+
+	TEST(fls, 0x0000, 0);
+	TEST(fls, 0x0001, 1);
+	TEST(fls, 0xff00, 16);
+	TEST(fls, 0x8000, 16);
+
+	TESTL(flsl, 0x00000000, 0);
+	TESTL(flsl, 0x00000001, 1);
+	TESTL(flsl, 0x00008000, 16);
+	TESTL(flsl, 0xffffffff, 32);
+	TESTL(flsl, 0x80000000, 32);
+
+	fprintf(stdout, "%d errors\n", errors);
+	return 0;
+}
+


### PR DESCRIPTION
This adds the missing string functions from FreeBSD 9 (newer C/POSIX standards) and moves some stuff to <strings.h>.  There's also an update to the make file so segment names can be passed to occ rather than put in the file.

Not currently included:
- man pages
- strcoll (locale)
- strxfrm (locale)
- ffsll (long long)
- flsll (long long)
