### PR TITLE
chtyp languages

### DIFF
--- a/bin/chtyp/chtyp.1
+++ b/bin/chtyp/chtyp.1
@@ -63,8 +63,9 @@ or
 .IR -a
 flags.
 .IP
-Valid language types are: APWTXT, ASM, PASCAL, EXEC, CC, LINKER,
-DESKTOP, REZ, TMLPASCAL, DISASM, SDEASM, SDECMD, PS.
+Valid language types are: APWTXT, ASM, IBASIC, PASCAL, EXEC, CC,
+LINKER, DESKTOP, REZ, TMLPASCAL, GSOFT, MODULA2, DISASM, SDEASM,
+SDECMD, PS.
 .SH HISTORY
 .BR chtyp
 was originally written by Greg Thompson.  Jawaid Bazyar rewrote it 

--- a/bin/chtyp/chtyp.c
+++ b/bin/chtyp/chtyp.c
@@ -140,6 +140,6 @@ static void usage(void)
 static void version(void)
 {
     (void) fprintf(stderr,
-		"V 2.0.0 Copyright 1997 by Evan Day, day@engr.orst.edu\n");
+		"V 2.0.1 Copyright 1997 by Evan Day, day@engr.orst.edu\n");
     usage();
 }

--- a/bin/chtyp/ftypes.c
+++ b/bin/chtyp/ftypes.c
@@ -126,6 +126,7 @@ static struct lang_list {
 } langs[] = {
 	{ "apwtxt",    0xb0, 0x0001},
 	{ "asm",       0xb0, 0x0003},
+	{ "ibasic",    0xb0, 0x0004},
 	{ "pascal",    0xb0, 0x0005},
 	{ "exec",      0xb0, 0x0006},
 	{ "cc",        0xb0, 0x0008},
@@ -134,13 +135,15 @@ static struct lang_list {
 	{ "desktop",   0xb0, 0x000c},
 	{ "rez",       0xb0, 0x0015},
 	{ "tmlpascal", 0xb0, 0x001e},
+	{ "gsoft",     0xb0, 0x0104},
+	{ "modula2",   0xb0, 0x0110},
 	{ "disasm",    0xb0, 0x0115},
 	{ "sdeasm",    0xb0, 0x0503},
 	{ "sdecmd",    0xb0, 0x0506},
 	{ "ps",        0xb0, 0x0719},
 };
 
-#define NUM_LANGS 14
+#define NUM_LANGS 17
 
 int find_type(char *type_str, int *f, long *a) 
 {

--- a/bin/chtyp/ftypes.c
+++ b/bin/chtyp/ftypes.c
@@ -141,9 +141,10 @@ static struct lang_list {
 	{ "sdeasm",    0xb0, 0x0503},
 	{ "sdecmd",    0xb0, 0x0506},
 	{ "ps",        0xb0, 0x0719},
+	{ "mdbasic",   0xb0, 0x0a04},
 };
 
-#define NUM_LANGS 17
+#define NUM_LANGS 18
 
 int find_type(char *type_str, int *f, long *a) 
 {


### PR DESCRIPTION
Added ibasic, gsoft, and modula2 as recognized languages for chtyp.
