### PR TITLE
fix binprint.1 synopsis

### DIFF
--- a/bin/binprint/binprint.1
+++ b/bin/binprint/binprint.1
@@ -4,7 +4,7 @@
 .TH BINPRINT 1 "15 January 1998" GNO "Commands and Applications"
 .SH NAME
 .BR binprint
-\- print Appleworks GS formatted manual pages
+\- display data in hex-dump format
 .SH SYNOPSIS
 .BR binprint
 [


### PR DESCRIPTION
`binprint.1` has confused itself with aroff.
